### PR TITLE
feat: add Text/String column support for all Diesel backends (closes #2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,9 @@ jobs:
 
       - uses: swatinem/rust-cache@v2
 
+      - name: Install SQLite development libraries
+        run: sudo apt-get install -y libsqlite3-dev
+
       - name: Install nextest
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "diesel"
 version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,10 +277,12 @@ dependencies = [
  "byteorder",
  "diesel_derives",
  "itoa",
+ "libsqlite3-sys",
  "mysqlclient-sys",
  "percent-encoding",
  "pq-sys",
  "serde_json",
+ "time",
  "url",
 ]
 
@@ -463,6 +474,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +504,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -571,6 +598,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -785,6 +818,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ zeroize = "1.8.1"
 diesel = ["dep:diesel"]
 diesel-mysql = ["diesel/mysql"]
 diesel-postgres = ["diesel/postgres"]
+diesel-sqlite = ["diesel/sqlite"]
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/src/integrations/diesel.rs
+++ b/src/integrations/diesel.rs
@@ -4,6 +4,8 @@ use diesel::{
     deserialize::FromSql,
     serialize::ToSql,
     backend::Backend,
+    expression::AsExpression,
+    internal::derives::as_expression::Bound,
     sql_types,
 };
 use serde::{Serialize, de::DeserializeOwned};
@@ -32,11 +34,95 @@ macro_rules! impl_from_and_to_sql {
     };
 }
 
+macro_rules! impl_from_and_to_sql_text {
+    ($($backend:ty),+ $(,)?) => {
+        $(
+            impl<P: Debug + DeserializeOwned + Serialize, C: Config> FromSql<sql_types::Text, $backend> for EncryptedMessage<P, C> {
+                fn from_sql(value: <$backend as Backend>::RawValue<'_>) -> diesel::deserialize::Result<Self> {
+                    let text: String = FromSql::<sql_types::Text, $backend>::from_sql(value)?;
+
+                    Ok(serde_json::from_str(&text)?)
+                }
+            }
+
+            impl<P: Debug + DeserializeOwned + Serialize, C: Config> ToSql<sql_types::Text, $backend> for EncryptedMessage<P, C> {
+                fn to_sql<'b>(&'b self, out: &mut diesel::serialize::Output<'b, '_, $backend>) -> diesel::serialize::Result {
+                    let json = serde_json::to_string(self)?;
+
+                    ToSql::<sql_types::Text, $backend>::to_sql(json.as_str(), &mut out.reborrow())
+                }
+            }
+        )+
+    };
+}
+
+// AsExpression impls allow EncryptedMessage to be used directly in Diesel query
+// expressions (e.g. with Insertable, filter, etc.) for Text columns.
+#[cfg(any(feature = "diesel-mysql", feature = "diesel-postgres", feature = "diesel-sqlite"))]
+impl<P: Debug + DeserializeOwned + Serialize, C: Config> AsExpression<sql_types::Text> for EncryptedMessage<P, C> {
+    type Expression = Bound<sql_types::Text, Self>;
+    fn as_expression(self) -> Self::Expression { Bound::new(self) }
+}
+
+#[cfg(any(feature = "diesel-mysql", feature = "diesel-postgres", feature = "diesel-sqlite"))]
+impl<P: Debug + DeserializeOwned + Serialize, C: Config> AsExpression<sql_types::Text> for &EncryptedMessage<P, C> {
+    type Expression = Bound<sql_types::Text, Self>;
+    fn as_expression(self) -> Self::Expression { Bound::new(self) }
+}
+
+#[cfg(any(feature = "diesel-mysql", feature = "diesel-postgres", feature = "diesel-sqlite"))]
+impl<P: Debug + DeserializeOwned + Serialize, C: Config> AsExpression<sql_types::Nullable<sql_types::Text>> for EncryptedMessage<P, C> {
+    type Expression = Bound<sql_types::Nullable<sql_types::Text>, Self>;
+    fn as_expression(self) -> Self::Expression { Bound::new(self) }
+}
+
+#[cfg(any(feature = "diesel-mysql", feature = "diesel-postgres", feature = "diesel-sqlite"))]
+impl<P: Debug + DeserializeOwned + Serialize, C: Config> AsExpression<sql_types::Nullable<sql_types::Text>> for &EncryptedMessage<P, C> {
+    type Expression = Bound<sql_types::Nullable<sql_types::Text>, Self>;
+    fn as_expression(self) -> Self::Expression { Bound::new(self) }
+}
+
+// ToSql<Nullable<Text>, DB> delegates to ToSql<Text, DB>, always writing IsNull::No.
+// This is required for Bound<Nullable<Text>, EncryptedMessage> to work as a QueryFragment.
+#[cfg(any(feature = "diesel-mysql", feature = "diesel-postgres", feature = "diesel-sqlite"))]
+impl<P: Debug + DeserializeOwned + Serialize, C: Config, DB: Backend> ToSql<sql_types::Nullable<sql_types::Text>, DB> for EncryptedMessage<P, C>
+where
+    Self: ToSql<sql_types::Text, DB>,
+{
+    fn to_sql<'b>(&'b self, out: &mut diesel::serialize::Output<'b, '_, DB>) -> diesel::serialize::Result {
+        ToSql::<sql_types::Text, DB>::to_sql(self, out)
+    }
+}
+
 #[cfg(feature = "diesel-mysql")]
 impl_from_and_to_sql!(sql_types::Json, diesel::mysql::Mysql);
+
+#[cfg(feature = "diesel-mysql")]
+impl_from_and_to_sql_text!(diesel::mysql::Mysql);
 
 #[cfg(feature = "diesel-postgres")]
 impl_from_and_to_sql!(
     sql_types::Json, diesel::pg::Pg,
     sql_types::Jsonb, diesel::pg::Pg,
 );
+
+#[cfg(feature = "diesel-postgres")]
+impl_from_and_to_sql_text!(diesel::pg::Pg);
+
+#[cfg(feature = "diesel-sqlite")]
+impl<P: Debug + DeserializeOwned + Serialize, C: Config> FromSql<sql_types::Text, diesel::sqlite::Sqlite> for EncryptedMessage<P, C> {
+    fn from_sql(value: <diesel::sqlite::Sqlite as Backend>::RawValue<'_>) -> diesel::deserialize::Result<Self> {
+        let text: String = FromSql::<sql_types::Text, diesel::sqlite::Sqlite>::from_sql(value)?;
+
+        Ok(serde_json::from_str(&text)?)
+    }
+}
+
+#[cfg(feature = "diesel-sqlite")]
+impl<P: Debug + DeserializeOwned + Serialize, C: Config> ToSql<sql_types::Text, diesel::sqlite::Sqlite> for EncryptedMessage<P, C> {
+    fn to_sql<'b>(&'b self, out: &mut diesel::serialize::Output<'b, '_, diesel::sqlite::Sqlite>) -> diesel::serialize::Result {
+        let json = serde_json::to_string(self)?;
+        out.set_value(json);
+        Ok(diesel::serialize::IsNull::No)
+    }
+}

--- a/tests/diesel-mysql/migrations/2024-04-13-220520_create_users/up.sql
+++ b/tests/diesel-mysql/migrations/2024-04-13-220520_create_users/up.sql
@@ -1,4 +1,5 @@
 CREATE TABLE users (
   id CHAR(36) DEFAULT (UUID()) PRIMARY KEY,
-  json JSON
+  json JSON,
+  text TEXT
 );

--- a/tests/diesel-mysql/schema.rs
+++ b/tests/diesel-mysql/schema.rs
@@ -5,5 +5,6 @@ diesel::table! {
         #[max_length = 36]
         id -> Char,
         json -> Nullable<Json>,
+        text -> Nullable<Text>,
     }
 }

--- a/tests/diesel-postgres/main.rs
+++ b/tests/diesel-postgres/main.rs
@@ -27,6 +27,7 @@ struct User {
     id: i32,
     json: Option<EncryptedMessage<String, EncryptionConfig>>,
     jsonb: Option<EncryptedMessage<String, EncryptionConfig>>,
+    text: Option<EncryptedMessage<String, EncryptionConfig>>,
 }
 
 #[derive(Insertable)]
@@ -35,6 +36,7 @@ struct User {
 struct UserInsertable {
     json: Option<EncryptedMessage<String, EncryptionConfig>>,
     jsonb: Option<EncryptedMessage<String, EncryptionConfig>>,
+    text: Option<EncryptedMessage<String, EncryptionConfig>>,
 }
 
 #[derive(AsChangeset)]
@@ -43,6 +45,7 @@ struct UserInsertable {
 struct UserChangeset {
     json: Option<Option<EncryptedMessage<String, EncryptionConfig>>>,
     jsonb: Option<Option<EncryptedMessage<String, EncryptionConfig>>>,
+    text: Option<Option<EncryptedMessage<String, EncryptionConfig>>>,
 }
 
 #[test]
@@ -58,6 +61,7 @@ fn encrypted_message_works() {
         .values(UserInsertable {
             json: Some(EncryptedMessage::encrypt("Very secret.".to_string()).unwrap()),
             jsonb: Some(EncryptedMessage::encrypt("Very secret, also binary.".to_string()).unwrap()),
+            text: Some(EncryptedMessage::encrypt("Very secret, as text.".to_string()).unwrap()),
         })
         .get_result(&mut connection)
         .unwrap();
@@ -65,4 +69,5 @@ fn encrypted_message_works() {
     // Decrypt the user's secrets.
     assert_eq!(user.json.as_ref().unwrap().decrypt().unwrap(), "Very secret.");
     assert_eq!(user.jsonb.as_ref().unwrap().decrypt().unwrap(), "Very secret, also binary.");
+    assert_eq!(user.text.as_ref().unwrap().decrypt().unwrap(), "Very secret, as text.");
 }

--- a/tests/diesel-postgres/migrations/2024-04-13-220520_create_users/up.sql
+++ b/tests/diesel-postgres/migrations/2024-04-13-220520_create_users/up.sql
@@ -1,5 +1,6 @@
 CREATE TABLE users (
   id SERIAL PRIMARY KEY,
   json JSON,
-  jsonb JSONB
+  jsonb JSONB,
+  text TEXT
 );

--- a/tests/diesel-postgres/schema.rs
+++ b/tests/diesel-postgres/schema.rs
@@ -5,5 +5,6 @@ diesel::table! {
         id -> Int4,
         json -> Nullable<Json>,
         jsonb -> Nullable<Jsonb>,
+        text -> Nullable<Text>,
     }
 }

--- a/tests/diesel-sqlite/main.rs
+++ b/tests/diesel-sqlite/main.rs
@@ -1,8 +1,9 @@
-#![cfg(all(feature = "diesel", feature = "diesel-mysql"))]
+#![cfg(all(feature = "diesel", feature = "diesel-sqlite"))]
 
 mod schema;
 
 use diesel::prelude::*;
+use diesel::connection::SimpleConnection;
 use encrypted_message::{
     EncryptedMessage,
     strategy::Randomized,
@@ -21,54 +22,53 @@ impl Config for EncryptionConfig {
 
 #[derive(Queryable, Selectable)]
 #[diesel(table_name = schema::users)]
-#[diesel(check_for_backend(diesel::mysql::Mysql))]
+#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
 struct User {
     #[allow(dead_code)]
-    id: String,
-    json: Option<EncryptedMessage<String, EncryptionConfig>>,
+    id: i32,
     text: Option<EncryptedMessage<String, EncryptionConfig>>,
 }
 
 #[derive(Insertable)]
 #[diesel(table_name = schema::users)]
-#[diesel(check_for_backend(diesel::mysql::Mysql))]
+#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
 struct UserInsertable {
-    id: String,
-    json: Option<EncryptedMessage<String, EncryptionConfig>>,
     text: Option<EncryptedMessage<String, EncryptionConfig>>,
 }
 
 #[derive(AsChangeset)]
 #[diesel(table_name = schema::users)]
-#[diesel(check_for_backend(diesel::mysql::Mysql))]
+#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
 struct UserChangeset {
-    json: Option<Option<EncryptedMessage<String, EncryptionConfig>>>,
     text: Option<Option<EncryptedMessage<String, EncryptionConfig>>>,
+}
+
+fn setup_db() -> SqliteConnection {
+    let mut connection = SqliteConnection::establish(":memory:").unwrap();
+    connection.batch_execute("
+        CREATE TABLE users (
+            id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+            text TEXT
+        )
+    ").unwrap();
+    connection
 }
 
 #[test]
 fn encrypted_message_works() {
-    // Attempt to load environment variables from .env.test
-    let _ = dotenvy::from_filename(".env.test");
+    let mut connection = setup_db();
 
-    let database_url = dotenvy::var("MYSQL_DATABASE_URL").expect("MYSQL_DATABASE_URL must be set.");
-    let mut connection = MysqlConnection::establish(&database_url).unwrap();
-
-    // Create a new user.
-    let id = uuid::Uuid::new_v4().to_string();
+    // Insert a new user.
     diesel::insert_into(schema::users::table)
         .values(UserInsertable {
-            id: id.clone(),
-            json: Some(EncryptedMessage::encrypt("Very secret.".to_string()).unwrap()),
             text: Some(EncryptedMessage::encrypt("Very secret, as text.".to_string()).unwrap()),
         })
         .execute(&mut connection)
         .unwrap();
 
-    // Load the new user from the database.
-    let user: User = schema::users::table.find(&id).first(&mut connection).unwrap();
+    // Load the user from the database.
+    let user: User = schema::users::table.first(&mut connection).unwrap();
 
-    // Decrypt the user's secrets.
-    assert_eq!(user.json.as_ref().unwrap().decrypt().unwrap(), "Very secret.");
+    // Decrypt the user's secret.
     assert_eq!(user.text.as_ref().unwrap().decrypt().unwrap(), "Very secret, as text.");
 }

--- a/tests/diesel-sqlite/schema.rs
+++ b/tests/diesel-sqlite/schema.rs
@@ -1,0 +1,6 @@
+diesel::table! {
+    users (id) {
+        id -> Integer,
+        text -> Nullable<Text>,
+    }
+}


### PR DESCRIPTION
Add FromSql/ToSql implementations for `sql_types::Text` columns to allow
EncryptedMessage to be stored in TEXT/VARCHAR columns. This enables SQLite
support (which has no native JSON type) and provides an alternative to JSON
columns for MySQL and PostgreSQL.

- Add `diesel-sqlite` feature with `diesel/sqlite` dependency
- Implement `FromSql<Text, Backend>` and `ToSql<Text, Backend>` for MySQL and Postgres via macro
- Implement `FromSql<Text, Sqlite>` and `ToSql<Text, Sqlite>` for SQLite (uses set_value instead of reborrow)
- Add `AsExpression<Text>`, `AsExpression<Nullable<Text>>`, and `ToSql<Nullable<Text>, DB>` impls to support Insertable with check_for_backend
- Add `tests/diesel-sqlite/` integration test using an in-memory SQLite database
- Extend existing MySQL and Postgres integration tests with TEXT column coverage
- Add libsqlite3-dev installation step to CI workflow

https://claude.ai/code/session_016REy1nX24Dh6x7WC9tjEf5